### PR TITLE
add feature

### DIFF
--- a/software/products/pom.xml
+++ b/software/products/pom.xml
@@ -66,11 +66,28 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk.crt</groupId>
+                    <artifactId>aws-crt</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <version>24.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -172,6 +189,7 @@
                             <mainClass>com.amazonaws.services.lambda.runtime.api.client.AWSLambda</mainClass>
                             <buildArgs>
                                 <arg>--enable-url-protocols=http</arg>
+                                <arg>--features=software.amazonaws.example.product.NativeFeature</arg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/software/products/src/assembly/zip.xml
+++ b/software/products/src/assembly/zip.xml
@@ -19,5 +19,11 @@
             <destName>bootstrap</destName>
             <fileMode>777</fileMode>
         </file>
+        <file>
+            <source>${project.build.directory}${file.separator}libaws-crt-jni.so</source>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <destName>libaws-crt-jni.so</destName>
+            <fileMode>777</fileMode>
+        </file>
     </files>
 </assembly>

--- a/software/products/src/main/java/software/amazonaws/example/product/NativeFeature.java
+++ b/software/products/src/main/java/software/amazonaws/example/product/NativeFeature.java
@@ -1,0 +1,14 @@
+
+package software.amazonaws.example.product;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import software.amazon.awssdk.crt.CRT;
+
+public class NativeFeature implements Feature {
+
+    @Override
+    public void afterImageWrite(AfterImageWriteAccess access) {
+      new CRT();
+      CRT.extractLibrary(access.getImagePath().getParent().toString());
+    }
+}

--- a/software/products/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/resource-config.json
+++ b/software/products/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/resource-config.json
@@ -13,6 +13,17 @@
       {
         "pattern": "\\Qjni/libaws-lambda-jni.linux_musl-x86_64.so\\E"
       }
+    ],
+    "excludes": [
+      {
+        "pattern": ".*libaws-crt-jni.dylib"
+      },
+      {
+        "pattern": ".*libaws-crt-jni.so"
+      },
+      {
+        "pattern": ".*aws-crt-jni.dll"
+      }
     ]
   },
   "bundles": []


### PR DESCRIPTION
*Issue #, if available:*

- Add a feature for GraalVM to extract the JNI lib during build process, so that it can improve the start-up time by skipping the extract and write for the shared lib for CRT.
- Currently as `extractLibrary` from CRT is still in a branch, you need to build CRT from source for this feature to work.
```
git clone https://github.com/awslabs/aws-crt-java.git
cd aws-crt-java
git checkout add-extract-lib-api
git submodule update --init --recursive
mvn install -DskipTests
```
- After you have a local build of aws-crt-java, you can keep build the example with this change.
- Also, added an exclusion for the resource that includes the JNI libs from CRT, which helps to reduce the artifacts size

*Description of changes:*

- Once the `extractLibrary` method available from CRT maven package, we can remove the exclusion for aws-crt and dependency on the local build.

- current `crt-graalvm-update` branch:
  - binary size: `-rwxr-xr-x 1 root root 136M Aug 12 23:07 product-binary`
  - zip size: `-rw-r--r-- 1 root root  45M Aug 12 23:07 function.zip`
![Screenshot 2024-08-12 at 4 26 00 PM](https://github.com/user-attachments/assets/6f46aefa-a61e-4818-bffe-83bacaefb83a)

- with this change:
  - binary size: `-rwxr-xr-x 1 root root  94M Aug 12 22:57 product-binary`
  - shared lib size: `-r-xr--r-- 1 root root 5.3M Aug 12 22:57 libaws-crt-jni.so` 
  - zip size: `-rw-r--r-- 1 root root  31M Aug 12 22:57 function.zip`
![Screenshot 2024-08-12 at 4 05 06 PM](https://github.com/user-attachments/assets/4564e98e-f763-42a6-a909-cf28fd0493a8)


Well... Based on the cloudwatch log, seems like this doesn't improve the loading time, which is possible that Lambda always extract everything from the zip during initialization, so, it has the same extracting and writing step with or without the shared lib already loaded or not. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
